### PR TITLE
Github Enterprise support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,5 +20,15 @@ Optionally you may also specify the domain (for GHE users):
 
 ::
 
-    GITHUB_DOMAIN = "api.github.com"
+    GITHUB_BASE_DOMAIN = "git.example.com"
 
+    GITHUB_API_DOMAIN = "api.git.example.com"
+
+
+If Subdomain isolation is disabled in GHE:
+
+::
+
+    GITHUB_BASE_DOMAIN = "git.example.com"
+
+    GITHUB_API_DOMAIN = "git.example.com/api/v3"

--- a/sentry_auth_github/client.py
+++ b/sentry_auth_github/client.py
@@ -5,7 +5,7 @@ from sentry import http
 from sentry.utils import json
 from urllib import urlencode
 
-from .constants import DOMAIN
+from .constants import API_DOMAIN
 
 
 class GitHubApiError(Exception):
@@ -31,7 +31,7 @@ class GitHubClient(object):
         }
 
         try:
-            req = self.http.get('https://{0}/{1}'.format(DOMAIN, path.lstrip('/')),
+            req = self.http.get('https://{0}/{1}'.format(API_DOMAIN, path.lstrip('/')),
                 params=params,
                 headers=headers,
             )

--- a/sentry_auth_github/constants.py
+++ b/sentry_auth_github/constants.py
@@ -2,11 +2,6 @@ from __future__ import absolute_import, print_function
 
 from django.conf import settings
 
-
-AUTHORIZE_URL = 'https://github.com/login/oauth/authorize'
-
-ACCESS_TOKEN_URL = 'https://github.com/login/oauth/access_token'
-
 CLIENT_ID = getattr(settings, 'GITHUB_APP_ID', None)
 
 CLIENT_SECRET = getattr(settings, 'GITHUB_API_SECRET', None)
@@ -18,4 +13,11 @@ ERR_MISSING_EMAIL = 'We were unable to determine the email address of your GitHu
 # we request repo as we share scopes with the other GitHub integration
 SCOPE = 'user:email,read:org,repo'
 
+# deprecated please use GITHUB_API_DOMAIN and GITHUB_BASE_DOMAIN
 DOMAIN = getattr(settings, 'GITHUB_DOMAIN', 'api.github.com')
+
+BASE_DOMAIN = getattr(settings, 'GITHUB_BASE_DOMAIN', 'github.com')
+API_DOMAIN = getattr(settings, 'GITHUB_API_DOMAIN', DOMAIN)
+
+ACCESS_TOKEN_URL = 'https://{0}/login/oauth/access_token'.format(BASE_DOMAIN)
+AUTHORIZE_URL = 'https://{0}/login/oauth/authorize'.format(BASE_DOMAIN)


### PR DESCRIPTION
Github Enterprise domain wasn't used in `AUTHORIZE_URL` and `ACCESS_TOKEN_URL` and needed to separate `DOMAIN` from `API_DOMAIN`.
