### PR TITLE
handling hidden emails

### DIFF
--- a/sentry_auth_github/client.py
+++ b/sentry_auth_github/client.py
@@ -45,6 +45,9 @@ class GitHubClient(object):
     def get_user(self, access_token):
         return self._request('/user', access_token)
 
+    def get_emails(self, access_token):
+        return self._request('/user/emails', access_token)
+
     def is_org_member(self, access_token, org_id):
         org_list = self.get_org_list(access_token)
         org_id = str(org_id)

--- a/sentry_auth_github/views.py
+++ b/sentry_auth_github/views.py
@@ -23,7 +23,12 @@ class FetchUser(AuthView):
         user = self.client.get_user(access_token)
         # TODO(dcramer): they should be able to enter an email
         if not user.get('email'):
-            return helper.error(ERR_MISSING_EMAIL)
+            # User is hiding his email in the profile, so we fetch only the primary one
+            emails = self.client.get_emails(access_token)
+            emails = [entry['email'] for entry in emails if entry['primary']]
+            if not emails:
+                return helper.error(ERR_MISSING_EMAIL)
+            user['email'] = emails[0]
 
         helper.bind_state('user', user)
 


### PR DESCRIPTION
If a Github user to hide his email, we can't get their email via the /user API call. So we need to fetch all emails via /user/emails and select only the primary one.
