### PR TITLE
Handle empty name in Github profile

### DIFF
--- a/sentry_auth_github/constants.py
+++ b/sentry_auth_github/constants.py
@@ -10,6 +10,8 @@ ERR_NO_ORG_ACCESS = 'You do not have access to the required GitHub organization.
 
 ERR_MISSING_EMAIL = 'We were unable to determine the email address of your GitHub account.'
 
+ERR_MISSING_NAME = 'We were unable to determine your name from your GitHub account.'
+
 # we request repo as we share scopes with the other GitHub integration
 SCOPE = 'user:email,read:org,repo'
 

--- a/sentry_auth_github/constants.py
+++ b/sentry_auth_github/constants.py
@@ -10,8 +10,6 @@ ERR_NO_ORG_ACCESS = 'You do not have access to the required GitHub organization.
 
 ERR_MISSING_EMAIL = 'We were unable to determine the email address of your GitHub account.'
 
-ERR_MISSING_NAME = 'We were unable to determine your name from your GitHub account.'
-
 # we request repo as we share scopes with the other GitHub integration
 SCOPE = 'user:email,read:org,repo'
 

--- a/sentry_auth_github/views.py
+++ b/sentry_auth_github/views.py
@@ -4,7 +4,7 @@ from django import forms
 from sentry.auth.view import AuthView, ConfigureView
 
 from .client import GitHubClient
-from .constants import ERR_NO_ORG_ACCESS, ERR_MISSING_EMAIL, ERR_MISSING_NAME
+from .constants import ERR_NO_ORG_ACCESS, ERR_MISSING_EMAIL
 
 
 def _get_name_from_email(email):

--- a/sentry_auth_github/views.py
+++ b/sentry_auth_github/views.py
@@ -7,6 +7,15 @@ from .client import GitHubClient
 from .constants import ERR_NO_ORG_ACCESS, ERR_MISSING_EMAIL, ERR_MISSING_NAME
 
 
+def _get_name_from_email(email):
+    """
+    Given an email return a capitalized name. Ex. john.smith@example.com would return John Smith.
+    """
+    name = email.rsplit('@', 1)[0]
+    name = ' '.join([n_part.capitalize() for n_part in name.split('.')])
+    return name
+
+
 class FetchUser(AuthView):
     def __init__(self, client_id, client_secret, org=None, *args, **kwargs):
         self.org = org
@@ -32,7 +41,7 @@ class FetchUser(AuthView):
 
         # A user hasn't set their name in their Github profile so it isn't populated in the response
         if not user.get('name'):
-            return helper.error(ERR_MISSING_NAME)
+            user['name'] = _get_name_from_email(user['email'])
 
         helper.bind_state('user', user)
 

--- a/sentry_auth_github/views.py
+++ b/sentry_auth_github/views.py
@@ -4,7 +4,7 @@ from django import forms
 from sentry.auth.view import AuthView, ConfigureView
 
 from .client import GitHubClient
-from .constants import ERR_NO_ORG_ACCESS, ERR_MISSING_EMAIL
+from .constants import ERR_NO_ORG_ACCESS, ERR_MISSING_EMAIL, ERR_MISSING_NAME
 
 
 class FetchUser(AuthView):
@@ -29,6 +29,10 @@ class FetchUser(AuthView):
             if not emails:
                 return helper.error(ERR_MISSING_EMAIL)
             user['email'] = emails[0]
+
+        # A user hasn't set their name in their Github profile so it isn't populated in the response
+        if not user.get('name'):
+            return helper.error(ERR_MISSING_NAME)
 
         helper.bind_state('user', user)
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,0 +1,18 @@
+from __future__ import absolute_import, print_function
+
+import pytest
+
+from sentry_auth_github.views import _get_name_from_email
+
+expected_data = [
+    ('john.smith@example.com', 'John Smith'),
+    ('john@example.com', 'John'),
+    ('XYZ-234=3523@example.com', 'Xyz-234=3523'),
+    ('XYZ.1111@example.com', 'Xyz 1111'),
+    ('JOHN@example.com', 'John'),
+]
+
+
+@pytest.mark.parametrize("email,expected_name", expected_data)
+def test_get_name_from_email(email, expected_name):
+    assert _get_name_from_email(email) == expected_name


### PR DESCRIPTION
Couple of our users hit this problem and none of them had a name set on their profile.
This will make them aware of it instead of returning an Internal Error.