### PR TITLE
sentry should acquire less permission

### DIFF
--- a/sentry_auth_github/constants.py
+++ b/sentry_auth_github/constants.py
@@ -19,7 +19,7 @@ ERR_NO_VERIFIED_PRIMARY_EMAIL = 'We were unable to find a verified, primary emai
 ERR_NO_SINGLE_VERIFIED_PRIMARY_EMAIL = 'We were unable to find a single verified, primary email address associated with your GitHub acount.'
 
 # we request repo as we share scopes with the other GitHub integration
-SCOPE = 'user:email,read:org,repo'
+SCOPE = 'user:email,read:org'
 
 # deprecated please use GITHUB_API_DOMAIN and GITHUB_BASE_DOMAIN
 DOMAIN = getattr(settings, 'GITHUB_DOMAIN', 'api.github.com')


### PR DESCRIPTION
It's really toooooo much to get member's private repo access.