### PR TITLE
Update README with steps to configure Github SSO

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,21 +13,31 @@ Install
 Setup
 -----
 
-Create a new application under your organization in GitHub. Enter the **Authorization
-callback URL** as the prefix to your Sentry installation:
+Create a new application under your organization in GitHub with at least the following configured. Example values given use `https://example.sentry.com` for the Sentry URL prefix and should be replaced with whatever hostname you use to access Sentry.
 
-::
+===============================  =====================================================
+App Option                       Value
+===============================  =====================================================
+Homepage URL                     https://example.sentry.com
+User authorization callback URL  https://example.sentry.com/auth/sso
+Webhook URL                      https://example.sentry.com/extensions/github/webhook/
+===============================  =====================================================
 
-    https://example.sentry.com
+========================  ===================
+Permissions               Access
+========================  ===================
+Organization permissions  Members - Read-only
+========================  ===================
 
+Afterwards, you will need to `install the GitHub app`__ on your organization.
 
-Once done, grab your API keys and drop them in your ``sentry.conf.py``:
+Once done, you will need the app's `Client ID` and `Client secret` to add them in your ``sentry.conf.py``:
 
 .. code-block:: python
 
-    GITHUB_APP_ID = ""
+    GITHUB_APP_ID = "" # client id
 
-    GITHUB_API_SECRET = ""
+    GITHUB_API_SECRET = "" # client secret
 
 
 Verified email addresses can optionally be required:
@@ -53,3 +63,5 @@ If Subdomain isolation is disabled in GHE:
     GITHUB_BASE_DOMAIN = "git.example.com"
 
     GITHUB_API_DOMAIN = "git.example.com/api/v3"
+
+__ https://developer.github.com/apps/installing-github-apps/#installing-your-private-github-app-on-your-repository

--- a/README.rst
+++ b/README.rst
@@ -23,11 +23,12 @@ User authorization callback URL  https://example.sentry.com/auth/sso
 Webhook URL                      https://example.sentry.com/extensions/github/webhook/
 ===============================  =====================================================
 
-========================  ===================
+========================  ===========================
 Permissions               Access
-========================  ===================
+========================  ===========================
 Organization permissions  Members - Read-only
-========================  ===================
+User permissions          Email addresses - Read-only
+========================  ===========================
 
 Afterwards, you will need to `install the GitHub app`__ on your organization.
 


### PR DESCRIPTION
I believe this should fix #23 and #24. The documentation was somewhat incomplete and I got it all put together from various issues strewn across other repositories. Hopefully this will make things a little more clear for future installations.

It also looks like the `GITHUB_APP_ID` is actually supposed to be the Github app's `Client ID` which I noted, but it might be nice if the environment variable name was consistent.

References:
#24
https://github.com/getsentry/sentry/issues/12670#issuecomment-505777363

Special thanks to @riker09, who I essentially followed his breadcrumbs across the issues to figure it out.