### PR TITLE
py3(django): use AppConfig to defer model imports via sentry.auth

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,33 @@
-sudo: false
+dist: xenial
 language: python
-services:
-  - memcached
-  - postgresql
-  - redis-server
 python:
   - '2.7'
 cache:
   directories:
     - node_modules
     - "$HOME/.cache/pip"
+
+matrix:
+  fast_finish: true
+  include:
+    - name: 'Linter'
+      script:
+        - pip install 'sentry-flake8==0.1.1'
+        - make lint
+    - name: 'Tests (sentry latest release)'
+      install:
+        - make ci-install-tests-sentry-latest
+      script:
+        - coverage run --source=. -m make test
+    - name: 'Tests (sentry git)'
+      install:
+        - make ci-install-tests-sentry-git
+      script:
+        - coverage run --source=. -m make test
+
+after_success:
+  - codecov
+
 deploy:
   provider: pypi
   user: getsentry
@@ -18,15 +36,3 @@ deploy:
   on:
     tags: true
   distributions: sdist bdist_wheel
-env:
-  global:
-    - PIP_DOWNLOAD_CACHE=".pip_download_cache"
-before_install:
-  - pip install codecov
-install:
-  - make develop
-script:
-  - PYFLAKES_NODOCTEST=1 flake8
-  - coverage run --source=. -m py.test tests
-after_success:
-  - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,10 @@ cache:
   directories:
     - node_modules
     - "$HOME/.cache/pip"
+services:
+  - memcached
+  - postgresql
+  - redis-server
 
 matrix:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,9 @@ addons:
     packages:
       - libxmlsec1-dev
 
+before_script:
+  - psql -c 'create database sentry;' -U postgres
+
 matrix:
   fast_finish: true
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,11 @@ services:
   - memcached
   - postgresql
   - redis-server
+addons:
+  apt:
+    update: true
+    packages:
+      - libxmlsec1-dev
 
 matrix:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,14 +18,15 @@ matrix:
       install:
         - make ci-install-tests-sentry-latest
       script:
-        - coverage run --source=. -m make test
+        - make test
     - name: 'Tests (sentry git)'
       install:
         - make ci-install-tests-sentry-git
       script:
-        - coverage run --source=. -m make test
+        - make test
 
 after_success:
+  - pip install codecov
   - codecov
 
 deploy:

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,19 @@
 .PHONY: clean develop install-tests lint publish test
 
-develop:
-	pip install "pip>=7"
-	pip install -e .
-	make install-tests
+install-pip:
+	pip install "pip==19.2.3"
 
-install-tests:
+develop: install-pip
+	SENTRY_LIGHT_BUILD=1 pip install --no-use-pep517 -e "../sentry[dev]"
+	pip install -e .[tests]
+
+ci-install-tests-sentry-git: install-pip
+	pip install --no-use-pep517 'git+https://github.com/getsentry/sentry.git#egg=sentry[dev]'
+	pip install .[tests]
+
+ci-install-tests-sentry-latest: install-pip
+	# Note that requirements-test (setuptools tests_require) is in 9.1.2 but was removed in git.
+	pip install --no-use-pep517 'sentry[dev,tests]'
 	pip install .[tests]
 
 lint:

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ lint:
 
 test:
 	@echo "--> Running Python tests"
-	py.test tests || exit 1
+	py.test --cov . tests || exit 1
 	@echo ""
 
 publish:

--- a/conftest.py
+++ b/conftest.py
@@ -5,10 +5,6 @@ import os.path
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__)))
 
-# Run tests against sqlite for simplicity
-import os
-os.environ.setdefault('DB', 'sqlite')
-
 pytest_plugins = [
     'sentry.utils.pytest'
 ]

--- a/sentry_auth_github/__init__.py
+++ b/sentry_auth_github/__init__.py
@@ -1,7 +1,16 @@
 from __future__ import absolute_import
 
-from sentry.auth import register
+import django
 
-from .provider import GitHubOAuth2Provider
+if django.VERSION[:2] >= (1, 8):
+    # Django 1.9 specifically requires that models not be imported before setup,
+    # which sentry.auth does, so we need to use AppConfig here.
+    # Also works on 1.8.
+    default_app_config = "sentry_auth_github.apps.Config"
+else:
+    # Provide backwards compatibility.
+    from sentry.auth import register
 
-register('github', GitHubOAuth2Provider)
+    from .provider import GitHubOAuth2Provider
+
+    register('github', GitHubOAuth2Provider)

--- a/sentry_auth_github/apps.py
+++ b/sentry_auth_github/apps.py
@@ -1,0 +1,14 @@
+from __future__ import absolute_import
+
+from django.apps import AppConfig
+
+
+class Config(AppConfig):
+    name = "sentry_auth_github"
+
+    def ready(self):
+        from sentry.auth import register
+
+        from .provider import GitHubOAuth2Provider
+
+        register('github', GitHubOAuth2Provider)

--- a/sentry_auth_github/client.py
+++ b/sentry_auth_github/client.py
@@ -52,8 +52,8 @@ class GitHubClient(object):
 
     def is_org_member(self, access_token, org_id):
         org_list = self.get_org_list(access_token)
-        org_id = six.binary_type(org_id)
+        org_id = six.text_type(org_id)
         for o in org_list:
-            if six.binary_type((o['id'])) == org_id:
+            if six.text_type((o['id'])) == org_id:
                 return True
         return False

--- a/sentry_auth_github/client.py
+++ b/sentry_auth_github/client.py
@@ -54,6 +54,6 @@ class GitHubClient(object):
         org_list = self.get_org_list(access_token)
         org_id = six.binary_type(org_id)
         for o in org_list:
-            if six.binary_type((o['id']) == org_id:
+            if six.binary_type((o['id'])) == org_id:
                 return True
         return False

--- a/sentry_auth_github/client.py
+++ b/sentry_auth_github/client.py
@@ -1,5 +1,6 @@
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import
 
+import six
 from requests.exceptions import RequestException
 from sentry import http
 from sentry.utils import json
@@ -35,7 +36,7 @@ class GitHubClient(object):
                 headers=headers,
             )
         except RequestException as e:
-            raise GitHubApiError(unicode(e), status=getattr(e, 'status_code', 0))
+            raise GitHubApiError(six.text_type(e), status=getattr(e, 'status_code', 0))
         if req.status_code < 200 or req.status_code >= 300:
             raise GitHubApiError(req.content, status=req.status_code)
         return json.loads(req.content)
@@ -51,8 +52,8 @@ class GitHubClient(object):
 
     def is_org_member(self, access_token, org_id):
         org_list = self.get_org_list(access_token)
-        org_id = str(org_id)
+        org_id = six.binary_type(org_id)
         for o in org_list:
-            if str(o['id']) == org_id:
+            if six.binary_type((o['id']) == org_id:
                 return True
         return False

--- a/sentry_auth_github/views.py
+++ b/sentry_auth_github/views.py
@@ -128,7 +128,7 @@ class SelectOrganization(AuthView):
         form = SelectOrganizationForm(org_list, request.POST or None)
         if form.is_valid():
             org_id = form.cleaned_data['org']
-            org = [o for o in org_list if org_id == six.binary_type(o['id'])][0]
+            org = [o for o in org_list if org_id == six.text_type(o['id'])][0]
             helper.bind_state('org', org)
             return helper.next_step()
 

--- a/sentry_auth_github/views.py
+++ b/sentry_auth_github/views.py
@@ -1,5 +1,6 @@
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import
 
+import six
 from django import forms
 from sentry.auth.view import AuthView, ConfigureView
 from sentry.models import AuthIdentity
@@ -127,7 +128,7 @@ class SelectOrganization(AuthView):
         form = SelectOrganizationForm(org_list, request.POST or None)
         if form.is_valid():
             org_id = form.cleaned_data['org']
-            org = [o for o in org_list if org_id == str(o['id'])][0]
+            org = [o for o in org_list if org_id == six.binary_type(o['id'])][0]
             helper.bind_state('org', org)
             return helper.next_step()
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [wheel]
 universal = 1
 
-[pytest]
+[tool:pytest]
 python_files = test*.py
 addopts = --tb=native -p no:doctest
 norecursedirs = bin dist docs htmlcov script hooks node_modules .* {args}

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python
+
+from __future__ import absolute_import
+
 """
 sentry-auth-github
 ==================

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,11 @@ install_requires = [
     'sentry>=9.0.0',
 ]
 
+test_requires = [
+    "pytest==4.6.5",
+    "pytest-cov==2.5.1",
+]
+
 setup(
     name='sentry-auth-github',
     version='0.1.0',
@@ -28,7 +33,7 @@ setup(
     zip_safe=False,
     install_requires=install_requires,
     extras_require={
-        'tests': [],
+        'tests': test_requires,
     },
     include_package_data=True,
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -9,12 +9,7 @@ from setuptools import setup, find_packages
 
 
 install_requires = [
-    'sentry>=7.0.0',
-]
-
-tests_require = [
-    'mock',
-    'flake8>=2.0,<2.1',
+    'sentry>=9.0.0',
 ]
 
 setup(
@@ -29,8 +24,9 @@ setup(
     packages=find_packages(exclude=['tests']),
     zip_safe=False,
     install_requires=install_requires,
-    tests_require=tests_require,
-    extras_require={'tests': tests_require},
+    extras_require={
+        'tests': [],
+    },
     include_package_data=True,
     entry_points={
         'sentry.apps': [

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -1,6 +1,0 @@
-from sentry.testutils import TestCase
-
-
-class GitHubOAuth2ProviderTest(TestCase):
-    def test_simple(self):
-        pass

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import
 
 import pytest
 


### PR DESCRIPTION
See https://github.com/getsentry/sentry-auth-saml2/pull/47.